### PR TITLE
Don't fork to download the jar, use the Download library from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "bluebird": "^3.3.3",
     "chokidar": "^1.4.3",
+    "download": "^4.4.3",
     "fs": "0.0.2",
     "glob": "^7.0.0",
     "lodash": "^4.5.1",

--- a/src/ensime-server-update-coursier.coffee
+++ b/src/ensime-server-update-coursier.coffee
@@ -3,6 +3,7 @@ fs = require('fs')
 path = require('path')
 loglevel = require 'loglevel'
 _ = require 'lodash'
+download = require 'download'
 
 
 javaArgs = (dotEnsime, updateChanging = false) ->
@@ -70,19 +71,9 @@ module.exports = (tempdir, getPidLogger, failure) ->
     if fs.existsSync(tempdir + path.sep + 'coursier')
       runCoursier()
     else
-      # """curl -L -o coursier https://git.io/vgvpD && chmod +x coursier"""
       coursierUrl = 'https://git.io/vgvpD'
-      getCoursier = spawn('curl', ['-L', '-o', 'coursier', coursierUrl], {cwd: tempdir})
-      logPid(getCoursier)
-      getCoursier.on 'close', (exitCode) ->
-        if(exitCode == 0)
-          chmod = spawn('chmod', ['+x', 'coursier'], {cwd: tempdir})
-          logPid(chmod)
-          chmod.on 'close', (chmodExitCode) ->
-            if(chmodExitCode == 0)
-              runCoursier()
-            else
-              failure("Failed to chmod coursier", chmodExitCode)
+      download(mode: '0755').get(coursierUrl).dest(tempdir).rename('coursier').run (err) ->
+        if(err)
+          failure("Failed to download coursier", err)
         else
-          failure("Failed to get Coursier", exitCode)
-    
+          runCoursier()


### PR DESCRIPTION
Uses the download library already pulled in by the main [ensime-atom](/ensime/ensime-atom) package.

The download was failing in Windows which doesn't have chmod or curl installed by default (some may have it installed via cygwin or msysgit but natively it's not there).

This also feels more idiomatic of node.
