### PR TITLE
Run tests on Windows

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -51,7 +51,7 @@ module.exports = (grunt) ->
 
     shell:
       test:
-        command: 'node --harmony node_modules/.bin/jasmine-focused --coffee --captureExceptions --forceexit spec'
+        command: 'node --harmony node_modules/jasmine-focused/bin/jasmine-focused --coffee --captureExceptions --forceexit spec'
         options:
           stdout: true
           stderr: true
@@ -60,7 +60,7 @@ module.exports = (grunt) ->
         command: './node_modules/.bin/typings install'
       
       integration:
-        command: 'node --harmony node_modules/.bin/jasmine-focused --coffee --captureExceptions --forceexit spec-integration'
+        command: 'node --harmony node_modules/jasmine-focused/bin/jasmine-focused --coffee --captureExceptions --forceexit spec-integration'
         options:
           stdout: true
           stderr: true

--- a/spec/server-startup-utils-spec.coffee
+++ b/spec/server-startup-utils-spec.coffee
@@ -1,3 +1,5 @@
+path = require 'path'
+_ = require 'lodash'
 {fixClasspath, javaArgsOf, javaCmdOf} = require '../lib/server-startup-utils'
 
 describe 'server-startup', ->
@@ -6,7 +8,7 @@ describe 'server-startup', ->
       javaHome = '__javaHome__'
       classpathList = ['a.jar', 'b.jar', 'monkey.jar']
       fixedClasspath = fixClasspath(javaHome, classpathList)
-      expect(fixedClasspath).toBe('monkey.jar:a.jar:b.jar:__javaHome__/lib/tools.jar')
+      expect(fixedClasspath).toBe(_.join(['monkey.jar','a.jar','b.jar',path.join('__javaHome__','lib','tools.jar')], path.delimiter))
   
   describe 'javaArgsOf', ->
     it "should work without server flags", ->
@@ -25,4 +27,4 @@ describe 'server-startup', ->
     it 'should find java form .ensime', ->
       dotEnsime =
         javaHome: '__javaHome__'
-      expect(javaCmdOf(dotEnsime)).toBe '__javaHome__/bin/java'
+      expect(javaCmdOf(dotEnsime)).toBe path.join('__javaHome__','bin','java')


### PR DESCRIPTION
Tests were failing on Windows due to a shell script that's not needed (it just calls node anyway) and a couple places where the path separator and dir delimiter were hardcoded.

This should get tests passing on Windows too.
