### PR TITLE
Allow building without grunt installed globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "coffee-script": "^1.10.0",
     "fs-extra": "^0.26.5",
     "grunt": "^0.4.1",
+    "grunt-cli": "^1.1.0",
     "grunt-coffeelint": "0.0.15",
     "grunt-contrib-coffee": "^1.0.0",
     "grunt-contrib-copy": "^0.8.2",
@@ -47,6 +48,7 @@
     "grunt-shell": "^0.2.2",
     "grunt-ts": "^5.3.2",
     "jasmine-focused": "^1.0.7",
+    "rimraf": "^2.5.2",
     "typescript": "^1.8.7",
     "typings": "^0.7.9"
   }


### PR DESCRIPTION
Currently `npm install` in a fresh checkout. First it complains that it can't find the `grunt` command, after installing that it complains about grunt not finding the `rimraf` module.

This change adds both modules to `devDependencies`, which is sufficient for the prepublish task to pick them up.
