### PR TITLE
Updated the download link for the coursier.dms file

### DIFF
--- a/src/lib/ensime-server-update-coursier.ts
+++ b/src/lib/ensime-server-update-coursier.ts
@@ -98,8 +98,7 @@ export default function updateServer(tempdir: string, failure: (string, int) => 
           runCoursier()
         } else {
           logger.trace("no pre-existing coursier binary, downloading: " + tempdir)
-          // # coursierUrl = 'https://git.io/vgvpD' # Java 7
-          const coursierUrl = "https://git.io/v2L2P" // Java 6
+          const coursierUrl = 'https://git.io/vgvpD' // Java 7
 
           download({ mode: '0755' }).get(coursierUrl).dest(tempdir).rename('coursier').run((err) => {
             if (err) {


### PR DESCRIPTION
The URL currently used will 404 and the Ensime plugin cannot be started in Atom if coursier does has not been downloaded before.

This updates the URL to point a download that was already included but commented out.